### PR TITLE
fix: do not uppercap dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-openai-whisper==20231117
-sounddevice==0.4.6
-numpy==1.24.3
-python-docx==1.0.1
-PySide6==6.6.1
-SpeechRecognition==3.10.0
-pyaudio==0.2.13
-transformers==4.36.2
+openai-whisper>=20231117
+sounddevice>=0.4.6
+numpy>=1.24.3
+python-docx>=1.0.1
+PySide6>=6.6.1
+SpeechRecognition>=3.10.0
+pyaudio>=0.2.13
+transformers>=4.36.2


### PR DESCRIPTION
Dependencies should not be uppercapped, as this causes an artificial auto-deprecation of the packages when they could perfectly work with newer dependencies, and they cause dependencies hell when unnecessary. See: https://iscinumpy.dev/post/bound-version-constraints/

This PR fixes this issue. Note also that I tested and the app does work with the latest dependencies.

BTW it would be interesting to add the possibility to use Whisper Turbo models since the latest dependencies do appear to work fine, this can potentially speed up further the real-time processing.